### PR TITLE
require enum34 to supply enums in Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     zip_safe=False,
     cffi_modules=['samplerate/samplerate_build.py:ffibuilder'],
     setup_requires=['cffi>=1.0.0', 'pytest-runner'],
-    install_requires=['cffi>=1.0.0', 'numpy'],
+    install_requires=['cffi>=1.0.0', 'numpy', 'enum34;python_version<"3.4"'],
     tests_require=['pytest'],
 )


### PR DESCRIPTION
samplerate/converters.py import enum which was not added to the standard library until Python 3.4. This project claims to support Python 2, but it requires the enum34 backport module. This dependency should be included in the setup.py file.