### PR TITLE
Fix build of universal2 wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,14 @@ class CMakeBuild(build_ext):
         if "universal2" in self.plat_name:
             cmake_args += ["-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"]
 
+        # Set MACOSX_DEPLOYMENT_TARGET for macOS builds.
+        if (
+            self.plat_name.startswith("macosx-")
+            and "MACOSX_DEPLOYMENT_TARGET" not in os.environ
+        ):
+            target_version = self.plat_name.split("-")[1]
+            os.environ["MACOSX_DEPLOYMENT_TARGET"] = target_version
+
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,11 @@
 # https://github.com/pybind/cmake_example
 
 import os
-import platform
 from pathlib import Path
-import re
 import subprocess
 import sys
 from pathlib import Path
 
-import setuptools
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
@@ -104,11 +101,9 @@ class CMakeBuild(build_ext):
                 ]
                 build_args += ["--config", cfg]
 
-        if sys.platform.startswith("darwin"):
-            # Cross-compile support for macOS - respect ARCHFLAGS if set
-            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
-            if archs:
-                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+        # When building universal2 wheels, we need to set the architectures for CMake.
+        if "universal2" in self.plat_name:
+            cmake_args += ["-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"]
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -328,8 +328,8 @@ class CallbackResampler {
 
   CallbackResampler clone() const { return CallbackResampler(*this); }
   CallbackResampler &__enter__() { return *this; }
-  void __exit__(const py::object &exc_type, const py::object &exc,
-                const py::object &exc_tb) {
+  void __exit__(const py::object &/*exc_type*/, const py::object &/*exc*/,
+                const py::object &/*exc_tb*/) {
     _destroy();
   }
 };


### PR DESCRIPTION
When building in a `universal2` Python executable, `CMAKE_OSX_ARCHITECTURES` was not properly set. We ended up with an `universal2` binary with only the build architecture (e.g., `x86_64` for GitHub runners).