### PR TITLE
Adds cmake as a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2", "cmake"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The PR adds cmake as a build dependency.

## Problem

On some systems (e.g., google colab), the [cmake python package](https://pypi.org/project/cmake/) is pre-installed.
In this case, the `cmake` command calls a script that calls this package instead of the original `cmake` executable.

However, the python build system will create an empty build environment where the `cmake` python package is not available, leading to an import error.

## Solution

Adding `cmake` as a build dependency solves the problem by installing the cmake python package as part of the build environment.