### PR TITLE
Increase expected size of output sample buffer, to correctly handle input termination.

### DIFF
--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -40,6 +40,9 @@
 #define VERSION_INFO "nightly"
 #endif
 
+// This value was empirically and somewhat arbitrarily chosen; increase it for further safety.
+#define END_OF_INPUT_EXTRA_OUTPUT_FRAMES 10000
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -158,14 +161,15 @@ class Resampler {
     if (channels != _channels || channels == 0)
       throw std::domain_error("Invalid number of channels in input data.");
 
-    // Add a "fudge factor" of 10,000.  This is because the actual number of
+    // Add a "fudge factor" to the size. This is because the actual number of
     // output samples generated on the last call when input is terminated can
     // be more than the expected number of output samples during mid-stream
     // steady-state processing. (Also, when the stream is started, the number
     // of output samples generated will generally be zero or otherwise less
     // than the number of samples in mid-stream processing.)
     const auto new_size =
-        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio)) + 10000;
+        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio))
+        + END_OF_INPUT_EXTRA_OUTPUT_FRAMES;
 
     // allocate output array
     std::vector<size_t> out_shape{new_size};
@@ -191,6 +195,9 @@ class Resampler {
     if ((size_t)src_data.output_frames_gen < new_size) {
       out_shape[0] = src_data.output_frames_gen;
       output.resize(out_shape);
+    } else if ((size_t)src_data.output_frames_gen >= new_size) {
+      // This means our fudge factor is too small.
+      throw std::runtime_error("Generated more output samples than expected!");
     }
 
     return output;

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -158,8 +158,14 @@ class Resampler {
     if (channels != _channels || channels == 0)
       throw std::domain_error("Invalid number of channels in input data.");
 
+    // Add a "fudge factor" of 10,000.  This is because the actual number of
+    // output samples generated on the last call when input is terminated can
+    // be more than the expected number of output samples during mid-stream
+    // steady-state processing. (Also, when the stream is started, the number
+    // of output samples generated will generally be zero or otherwise less
+    // than the number of samples in mid-stream processing.)
     const auto new_size =
-        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio));
+        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio)) + 10000;
 
     // allocate output array
     std::vector<size_t> out_shape{new_size};


### PR DESCRIPTION
**Problem:** when using the full API (`.process()` method in this wrapper), the number of output samples is incorrect for a chunked input at the end of a stream.  This is because the calculation of `new_size` assumes that the number of output samples that will be generated will be at most the number of input samples times the resampling ratio.  While that's generally true for chunks processed mid-stream (as well as at the start of a stream), when the input is terminated it becomes possible for the output samples to exceed this expected length because the resampler's buffer is being flushed of any remaining data.

**Solution**: an ideal solution would be to determine the actual number of samples that will be flushed on an input-terminating call.  This is complicated to do, for various reasons related to issues such as https://github.com/libsndfile/libsamplerate/issues/6

As a hacky workaround, we can figure that adding a "fudge factor" of 10,000 samples ought to be sufficient.  In case that's not enough, a `RuntimeError` will be raised.

**Testing**: Here's a modified version of the example code on the `README` ... perhaps this chunked usage should be included in the documentation?

```python
#!/usr/bin/env python3

import numpy as np
import samplerate

# Synthesize data
fs = 1000.
t = np.arange(fs * 2) / fs
input_data = np.sin(2 * np.pi * 5 * t)

# Simple API
ratio = 1.5
converter = 'sinc_best'  # or 'sinc_fastest', ...
output_data_simple = samplerate.resample(input_data, ratio, converter)

# Full API
resampler = samplerate.Resampler(converter, channels=1)
output_data_full = resampler.process(input_data, ratio, end_of_input=True)

# The result is the same for both APIs.
assert np.allclose(output_data_simple, output_data_full)

# Full API, chunked
resampler.reset()
output_data_chunked = np.array([], dtype=np.float32)
chunk_size = 100
for i in range(0, len(input_data), chunk_size):
    chunk = input_data[i : i+chunk_size]
    resampled = resampler.process(chunk, ratio, end_of_input=False)
    print(f"{len(chunk)} input samples --> {len(resampled)} output samples")
    output_data_chunked = np.concatenate((output_data_chunked, resampled))
print(f"{len(output_data_chunked)} output samples before input is terminated")

# Terminate with an empty final chunk.
resampled = resampler.process([], ratio, end_of_input=True)
print(f"input terminated --> {len(resampled)} output samples")
output_data_chunked = np.concatenate((output_data_chunked, resampled))
print(f"{len(output_data_chunked)} output samples after input is terminated")

# The result is the same for all APIs.
assert np.allclose(output_data_chunked, output_data_simple)

# See `samplerate.CallbackResampler` for the Callback API, or
# `examples/play_modulation.py` for an example.
```