### PR TITLE
Updates pybind11 to v3.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
     CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
     (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
-    target_compile_options(python-samplerate PRIVATE -std=c++14 -O3 -Wall -Wextra)
+    target_compile_options(python-samplerate PRIVATE -std=c++14 -O3 -Wall -Wextra -fPIC)
 endif()
 
 ### stick the package and libsamplerate version into the module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # https://stackoverflow.com/questions/51907755/building-a-pybind11-module-with-cpp-and-cuda-sources-using-cmake
 
 cmake_minimum_required(VERSION 3.15)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
 message(STATUS "Found Python prefix ${PYTHON_PREFIX}")
 list(PREPEND CMAKE_PREFIX_PATH "${PYTHON_PREFIX}")
@@ -8,7 +9,7 @@ list(PREPEND CMAKE_PREFIX_PATH "${PYTHON_PREFIX}")
 project(python-samplerate)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-cmake_policy(SET CMP0094 NEW)
+cmake_policy(SET CMP0148 NEW)
 
 # adds the external dependencies
 add_subdirectory(external)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG 5b0a6fc2017fcc176545afe3e09c9f9885283242 # 2.10.4
+  GIT_TAG f5fbe867d2d26e4a0a9177a51f6e568868ad3dc8 # 3.0.1
 )
 
 FetchContent_MakeAvailable(pybind11)


### PR DESCRIPTION
Fixes issues #19 and #28 

* #19 Adds -fPIC compilation flag
* #28 Updates pybind11 to 3.0.1 and bump up the minimum required version in cmake file.