### PR TITLE
Enhance GIL management and error handling in resampling

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v3
     - name: Checkout submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,13 @@ classifiers=[
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Topic :: Scientific/Engineering",
   "Topic :: Multimedia :: Sound/Audio",
 ]
 keywords=["samplerate", "converter", "signal processing", "audio"]
-license = {text = "MIT"}
+license = "MIT"
 dependencies = ["numpy"]
 
 [tool.setuptools.dynamic]

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -40,6 +40,9 @@
 #define VERSION_INFO "nightly"
 #endif
 
+// This value was empirically and somewhat arbitrarily chosen; increase it for further safety.
+#define END_OF_INPUT_EXTRA_OUTPUT_FRAMES 10000
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -158,14 +161,15 @@ class Resampler {
     if (channels != _channels || channels == 0)
       throw std::domain_error("Invalid number of channels in input data.");
 
-    // Add a "fudge factor" of 10,000.  This is because the actual number of
+    // Add a "fudge factor" to the size. This is because the actual number of
     // output samples generated on the last call when input is terminated can
     // be more than the expected number of output samples during mid-stream
     // steady-state processing. (Also, when the stream is started, the number
     // of output samples generated will generally be zero or otherwise less
     // than the number of samples in mid-stream processing.)
     const auto new_size =
-        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio)) + 10000;
+        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio))
+        + END_OF_INPUT_EXTRA_OUTPUT_FRAMES;
 
     // allocate output array
     std::vector<size_t> out_shape{new_size};
@@ -191,6 +195,9 @@ class Resampler {
     if ((size_t)src_data.output_frames_gen < new_size) {
       out_shape[0] = src_data.output_frames_gen;
       output.resize(out_shape);
+    } else if ((size_t)src_data.output_frames_gen >= new_size) {
+      // This means our fudge factor is too small.
+      throw std::runtime_error("Generated more output samples than expected!");
     }
 
     return output;

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -346,6 +346,8 @@ long the_callback_func(void *cb_data, float **data) {
   CallbackResampler *cb = static_cast<CallbackResampler *>(cb_data);
   int cb_channels = cb->get_channels();
 
+  py::gil_scoped_acquire acquire;
+
   // get the data as a numpy array
   auto input = cb->callback();
 

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -158,8 +158,14 @@ class Resampler {
     if (channels != _channels || channels == 0)
       throw std::domain_error("Invalid number of channels in input data.");
 
+    // Add a "fudge factor" of 10,000.  This is because the actual number of
+    // output samples generated on the last call when input is terminated can
+    // be more than the expected number of output samples during mid-stream
+    // steady-state processing. (Also, when the stream is started, the number
+    // of output samples generated will generally be zero or otherwise less
+    // than the number of samples in mid-stream processing.)
     const auto new_size =
-        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio));
+        static_cast<size_t>(std::ceil(inbuf.shape[0] * sr_ratio)) + 10000;
 
     // allocate output array
     std::vector<size_t> out_shape{new_size};


### PR DESCRIPTION
Improve GIL management during resampling operations to prevent blocking and enhance performance. Update error handling to manage exceptions more effectively, particularly in callback scenarios. Adjust the expected output size to accommodate additional frames introduced by https://github.com/tuxu/python-samplerate/pull/22 and remove support for Python 3.8. Update license specification format.

The latter changes are from existing community PRs that have already been merged.