### PR TITLE
Fix ValueError in test_process by copying input array

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,7 +48,7 @@ def test_simple(data, converter_type, ratio=2.0):
 def test_process(data, converter_type, ratio=2.0):
     num_channels, input_data = data
     src = samplerate.Resampler(converter_type, num_channels)
-    src.process(input_data, ratio)
+    src.process(input_data.copy(), ratio)
 
 
 def test_match(data, converter_type, ratio=2.0):


### PR DESCRIPTION
This fixes an error seen with NumPy 2.4:

```
    def test_process(data, converter_type, ratio=2.0):
        num_channels, input_data = data
        src = samplerate.Resampler(converter_type, num_channels)
>       src.process(input_data, ratio)
E       ValueError: cannot resize an array that references or is referenced
E       by another array in this way.
E       Use the np.resize function or refcheck=False
```