### PR TITLE
Changes buffer resize to a view.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v3
     - name: Checkout submodules

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -315,8 +315,8 @@ class CallbackResampler {
     // create a shorter view of the array
     if (output_frames_gen < frames) {
       out_shape[0] = output_frames_gen;
-      auto strides = std::vector<ssize_t>(output.strides(),
-                                          output.strides() + output.ndim());
+      auto strides = std::vector<py::ssize_t>(output.strides(),
+                                              output.strides() + output.ndim());
       return py::array_t<float, py::array::c_style>(
         out_shape, strides, static_cast<float *>(outbuf.ptr), output);
     }

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -183,11 +183,11 @@ class Resampler {
 
     // create a shorter view of the array
     if ((size_t)src_data.output_frames_gen < new_size) {
-      out_shape[0] = src_data.output_frames_gen;
-      output.resize(out_shape);
+        return output[py::slice(0, src_data.output_frames_gen, 1)]
+            .cast<py::array_t<float, py::array::c_style>>();
+    } else {
+        return output;
     }
-
-    return output;
   }
 
   void set_ratio(double new_ratio) {
@@ -312,11 +312,11 @@ class CallbackResampler {
 
     // create a shorter view of the array
     if (output_frames_gen < frames) {
-      out_shape[0] = output_frames_gen;
-      output.resize(out_shape);
+        return output[py::slice(0, output_frames_gen, 1)]
+            .cast<py::array_t<float, py::array::c_style>>();
+    } else {
+        return output;
     }
-
-    return output;
   }
 
   void set_starting_ratio(double new_ratio) {
@@ -413,8 +413,8 @@ py::array_t<float, py::array::c_style> resample(
 
   // create a shorter view of the array
   if ((size_t)src_data.output_frames_gen < new_size) {
-    out_shape[0] = src_data.output_frames_gen;
-    output.resize(out_shape);
+      output = output[py::slice(0, src_data.output_frames_gen, 1)]
+                   .cast<py::array_t<float, py::array::c_style>>();
   }
 
   if (verbose) {

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -430,7 +430,7 @@ py::array_t<float, py::array::c_style> resample(
 
 namespace sr = samplerate;
 
-PYBIND11_MODULE(samplerate, m) {
+PYBIND11_MODULE(samplerate, m, py::mod_gil_not_used()) {
   m.doc() =
       "A simple python wrapper library around libsamplerate";  // optional
                                                                // module

--- a/src/samplerate.cpp
+++ b/src/samplerate.cpp
@@ -183,11 +183,13 @@ class Resampler {
 
     // create a shorter view of the array
     if ((size_t)src_data.output_frames_gen < new_size) {
-        return output[py::slice(0, src_data.output_frames_gen, 1)]
-            .cast<py::array_t<float, py::array::c_style>>();
-    } else {
-        return output;
+      out_shape[0] = src_data.output_frames_gen;
+      return py::array_t<float, py::array::c_style>(
+        out_shape, outbuf.strides, static_cast<float *>(outbuf.ptr),
+        output);
     }
+
+    return output;
   }
 
   void set_ratio(double new_ratio) {
@@ -312,11 +314,14 @@ class CallbackResampler {
 
     // create a shorter view of the array
     if (output_frames_gen < frames) {
-        return output[py::slice(0, output_frames_gen, 1)]
-            .cast<py::array_t<float, py::array::c_style>>();
-    } else {
-        return output;
+      out_shape[0] = output_frames_gen;
+      auto strides = std::vector<ssize_t>(output.strides(),
+                                          output.strides() + output.ndim());
+      return py::array_t<float, py::array::c_style>(
+        out_shape, strides, static_cast<float *>(outbuf.ptr), output);
     }
+
+    return output;
   }
 
   void set_starting_ratio(double new_ratio) {
@@ -413,8 +418,10 @@ py::array_t<float, py::array::c_style> resample(
 
   // create a shorter view of the array
   if ((size_t)src_data.output_frames_gen < new_size) {
-      output = output[py::slice(0, src_data.output_frames_gen, 1)]
-                   .cast<py::array_t<float, py::array::c_style>>();
+    out_shape[0] = src_data.output_frames_gen;
+    auto base = output;
+    output = py::array_t<float, py::array::c_style>(
+      out_shape, outbuf.strides, static_cast<float *>(outbuf.ptr), base);
   }
 
   if (verbose) {
@@ -430,7 +437,7 @@ py::array_t<float, py::array::c_style> resample(
 
 namespace sr = samplerate;
 
-PYBIND11_MODULE(samplerate, m, py::mod_gil_not_used()) {
+PYBIND11_MODULE(samplerate, m) {
   m.doc() =
       "A simple python wrapper library around libsamplerate";  // optional
                                                                // module


### PR DESCRIPTION
Sometimes the buffer returned by libsamplerate is slightly shorter than expected.
In this case, the length needs to be adjusted before it is returned.
So far, a call to numpy.resize was used. However, this is causing [problems](https://github.com/tuxu/python-samplerate/issues/35) with newer versions of python.
This PR changes the code to create a view of the correct size.
This has the added benefit of not triggering a reallocation of the buffer.