### PR TITLE
Fix wheels bundling wrong Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,10 @@
 cmake_minimum_required(VERSION 3.15)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
-message(STATUS "Found Python prefix ${PYTHON_PREFIX}")
-list(PREPEND CMAKE_PREFIX_PATH "${PYTHON_PREFIX}")
-
 project(python-samplerate)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-cmake_policy(SET CMP0148 NEW)
+set(PYBIND11_FINDPYTHON ON)
 
 # adds the external dependencies
 add_subdirectory(external)

--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,11 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
-        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
         # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
         # from Python.
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
-            f"-DPYTHON_EXECUTABLE={sys.executable}",
+            f"-DPython_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
         ]
         build_args = []


### PR DESCRIPTION
pybind11 v3.0.1 reads `Python_EXECUTABLE` instead of `PYTHON_EXECUTABLE`. The old variable name was silently ignored so that CMake's FindPython picked up whatever Python was first in the system PATH instead of the one running the build.

See https://github.com/pybind/pybind11/blob/master/tools/pybind11Config.cmake.in#L81

Fixes #34